### PR TITLE
Support Validation dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ dsd.run(my_training_function, subsets="Dev")
 dsd.run(my_test_function, subsets="Test")
 ```
 
+If you want to exclude tracks from the training you can specify track ids as  the `dsdtools.DB(..., validation_ids=[1, 2]`) object. Those tracks are then not included in `Dev` but are returned for `subsets="Valid"`.
+
+
 #### Processing single or multiple DSD100 tracks
 
 ```python

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ dsd.run(my_training_function, subsets="Dev")
 dsd.run(my_test_function, subsets="Test")
 ```
 
-If you want to exclude tracks from the training you can specify track ids as  the `dsdtools.DB(..., validation_ids=[1, 2]`) object. Those tracks are then not included in `Dev` but are returned for `subsets="Valid"`.
+If you want to exclude tracks from the training you can specify track ids as  the `dsdtools.DB(..., valid_ids=[1, 2]`) object. Those tracks are then not included in `Dev` but are returned for `subsets="Valid"`.
 
 
 #### Processing single or multiple DSD100 tracks

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,8 +55,8 @@ project = u'dsdtools'
 copyright = u'2016, Fabian-Robert Stöter'
 author = u'Fabian-Robert Stöter'
 
-version = u'0.1.1'
-release = u'0.1.1'
+version = u'0.1.2'
+release = u'0.1.2'
 
 language = None
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -106,6 +106,11 @@ training subset and then apply the algorithm on the test data:
     dsd.run(my_training_function, subsets="Dev")
     dsd.run(my_test_function, subsets="Test")
 
+If you want to exclude tracks from the training you can specify track ids as
+``dsdtools.DB(..., valid_ids=[1, 2]`` object. Those tracks are then not
+included in ``Dev`` but are returned for ``subsets="Valid"``.
+
+
 Processing single or multiple DSD100 tracks
 '''''''''''''''''''''''''''''''''''''''''''
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [pytest]
-norecursedirs = .env\* .cache .git examples
+norecursedirs = .env\* .cache .git examples docs
 addopts = --doctest-modules --cov-report term-missing --cov dsdtools --pep8
 
 [metadata]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
         name='dsdtools',
 
         # Version
-        version="0.1.1",
+        version="0.1.2",
 
         # Description
         description='Python tools for the Demixing Secrets Dataset (DSD)',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -81,6 +81,23 @@ def test_file_loading():
     assert len(tracks) == 1
 
 
+def test_file_loading_valid():
+    # initiate dsdtools
+
+    dsd = dsdtools.DB(root_dir="data/DSD100subset", valid_ids=55)
+    tracks = dsd.load_dsd_tracks(subsets='Dev')
+    # from two tracks there is only one track left (id=81)
+    assert len(tracks) == 1
+    assert tracks[0].id == 81
+
+    tracks = dsd.load_dsd_tracks(subsets='Valid')
+    assert len(tracks) == 1
+    assert tracks[0].id == 55
+
+    with pytest.raises(ValueError):
+        tracks = dsd.load_dsd_tracks(subsets=['Dev', 'Valid'])
+
+
 @pytest.fixture(params=['data/DSD100subset'])
 def dsd(request):
     return dsdtools.DB(root_dir=request.param)


### PR DESCRIPTION
Now one can specify validation ids which are excluded from the 'Dev' set. Those tracks are returned for `subsets="Valid"`.